### PR TITLE
feat(student): auto-update teacher studentCount on student deletion

### DIFF
--- a/models/Student.js
+++ b/models/Student.js
@@ -46,7 +46,23 @@ const studentSchema = new mongoose.Schema(
 );
 
 // middleware
-
+// Delete
+studentSchema.post("findByIdAndDelete", async (doc, next)=>{
+  try {
+    if(doc && doc.teacher){
+      await mongoose.model("Teacher").updateOne(
+        {id: teacher._id},
+        {
+          $pull: {student: doc.id},
+          $inc: {studentCount: -1},
+        }
+      );
+    }
+    next();
+  } catch (error) {
+    next(error);
+  }
+})
 // SAVE
 studentSchema.pre("save", function (next) {
   if (this.name) {


### PR DESCRIPTION
### Overview
This PR introduces middleware to keep the `Teacher` document in sync when a `Student` is deleted.  
Previously, deleting a student via `findByIdAndDelete` would remove the student record but leave stale references in the teacher document.

### Changes
- Added `post('findOneAndDelete')` middleware in `Student` schema:
  - Automatically removes the deleted student's ID from `teacher.students[]`
  - Decrements `teacher.studentCount`
- Ensures data consistency without requiring manual logic in controllers.

### Why
- Prevents orphaned references in `Teacher.students`
- Guarantees accurate `studentCount`
- Reduces risk of bugs if deletions are performed outside dedicated controller logic

### Testing
- Create a student with a teacher assigned
- Delete the student via `DELETE /students/:id`
- Confirm that:
  - Student is removed
  - Teacher’s `studentCount` is decremented
  - Teacher’s `students[]` no longer contains the student ID