### PR TITLE
 feat(change-streams): add real-time watcher for Student collection

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import dotenv from "dotenv";
+import { watchStudents } from "../controllers/changeStream";
 dotenv.config();
 
 const connectDB = async () => {
@@ -9,6 +10,7 @@ const connectDB = async () => {
       useUnifiedTopology: true,
     });
     console.log("MongoDB Connected!");
+    watchStudents();
   } catch (err) {
     console.log("Failed to connect MongoDB, Reason:", err);
     process.exit(1);

--- a/controllers/changeStream.js
+++ b/controllers/changeStream.js
@@ -1,0 +1,31 @@
+import Student from "../models/Student.js";
+
+export const watchStudents = () => {
+    
+  Student.watch().on("change", (change) => {
+    console.log(`Student collection change`);
+    console.log(JSON.stringify(change, null, 2));
+
+    switch (change.operationType) {
+      case "insert":
+        console.log(`Document created:`, change.fullDocument);
+        break;
+
+      case "update":
+        console.log(`Document updated:`, change.updateDescription);
+        break;
+
+      case "delete":
+        console.log(`Document deleted id:`, change.documentkey._id);
+        break;
+
+      case "replace":
+        console.log(`Document replace:`, change.fullDocument);
+        break;
+
+      default:
+        console.log(`Other Operations`, change);
+        break;
+    }
+  });
+};


### PR DESCRIPTION
 ## Summary
#   Introduces MongoDB Change Streams to listen for real-time changes on the `students` collection.
#   Automatically logs insert, update, delete, and replace events for easier debugging and live features.

#   ## Changes
- Implemented `watchStudents()` in `controllers/changeStream.js`
- Hooked the watcher in `config/db.js` after a successful DB connection
- Included structured logs for `insert`, `update` (with `updateDescription`), and `delete`
- Documented requirement to run MongoDB as a replica set (`--replSet rs0`)

#   ## Why
- Enables building real-time features (dashboards, notifications) without polling.
- Serves as a foundation for emitting events to WebSocket/Socket.IO in the next step.

#   ## Testing
1. Start MongoDB with replication (single-node rs is fine).
2. Start the server and observe logs: "Watching student collection for changes..."
3. Hit existing endpoints:
- POST /students  → should log an `insert` event with `fullDocument`
- PUT/PATCH /students/:id → should log an `update` event with `updateDescription`
- DELETE /students/:id → should log a `delete` event with `documentKey._id`
