### PR TITLE
feat: add 'subject' field to Teacher schema

### DIFF
--- a/models/Teacher.js
+++ b/models/Teacher.js
@@ -6,9 +6,10 @@ const teacherSchema = new mongoose.Schema({
   students: [
     {
       type: mongoose.Schema.Types.ObjectId,
-      ref: "Student",
+      ref: "Student"
     }
   ], 
+  subject: { type: String, default: "General" }
 }, {
   timestamps: true,
   versionKey: false


### PR DESCRIPTION
- Introduced a new field 'subject' with default value 'General'
- Helps categorize teachers by the subject they teach
- Keeps schema flexible for future filtering or querying